### PR TITLE
Update Docker Compose configurations and add SQL migration for style …

### DIFF
--- a/backend/src/main/resources/db/tenant/pagebuilder/V1.0.1__add_style_classes_to_pages.sql
+++ b/backend/src/main/resources/db/tenant/pagebuilder/V1.0.1__add_style_classes_to_pages.sql
@@ -1,0 +1,1 @@
+ALTER TABLE pages ADD COLUMN style_classes VARCHAR(255) NULL;

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -104,6 +104,9 @@ services:
       - backend
     environment:
       NODE_ENV: production
+      HOSTNAME: "0.0.0.0"
+      TENANT_SUBDOMAIN: ${STOREFRONT_TENANT_SUBDOMAIN:-demo}
+      NEXT_PUBLIC_CMS_API_URL: ${STOREFRONT_CMS_API_URL:-https://api.craftive.io/api}
     networks:
       - craftive-network
     labels:
@@ -118,7 +121,7 @@ services:
       - "traefik.http.routers.storefront.tls.certresolver=letsencrypt"
       - "traefik.http.services.storefront.loadbalancer.server.port=3000"
     healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:3000/api/health"]
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:3000/api/health"]
       interval: 30s
       timeout: 5s
       retries: 3

--- a/docker-compose.stage.yml
+++ b/docker-compose.stage.yml
@@ -31,6 +31,9 @@ services:
       - backend
     environment:
       NODE_ENV: production
+      HOSTNAME: "0.0.0.0"
+      TENANT_SUBDOMAIN: ${STOREFRONT_TENANT_SUBDOMAIN:-demo}
+      NEXT_PUBLIC_CMS_API_URL: ${STOREFRONT_CMS_API_URL:-https://s1-api.craftive.io/api}
     networks:
       - craftive-network
     labels:
@@ -43,7 +46,7 @@ services:
       - "traefik.http.routers.storefront.tls.certresolver=letsencrypt"
       - "traefik.http.services.storefront.loadbalancer.server.port=3000"
     healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:3000/api/health"]
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:3000/api/health"]
       interval: 30s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
…classes

- Added environment variables for HOSTNAME, TENANT_SUBDOMAIN, and NEXT_PUBLIC_CMS_API_URL in both production and staging Docker Compose files.
- Updated healthcheck command to use 127.0.0.1 instead of localhost for better compatibility.
- Introduced a new SQL migration script to add a style_classes column to the pages table.

These changes enhance environment configuration and database schema for improved functionality.

## Description

<!-- Provide a brief description of the changes in this PR -->

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] ♻️ Code refactoring
- [ ] 🎨 UI/UX improvement

## Related Issue

<!-- Link to the issue this PR addresses -->
Closes #

## Changes Made

<!-- List the main changes -->

- 
- 
- 

## Architecture Checklist

### Clean Architecture (CRITICAL)
- [ ] No layer boundary violations (Presentation → Application → Domain ← Infrastructure)
- [ ] Business logic is in Application layer only
- [ ] Domain layer has no external dependencies
- [ ] Infrastructure doesn't import Presentation

### Multi-Tenancy
- [ ] No `tenant_id` columns added (using database-per-tenant)
- [ ] TenantContext properly set/cleared in try-finally
- [ ] Platform entities use `@Qualifier("platformDataSource")` if applicable
- [ ] MDC logging includes tenantId, tenantDb, correlationId

## Code Quality Checklist

### Backend (Java/Spring Boot)
- [ ] Constructor injection only (no @Autowired)
- [ ] Using `jakarta.*` packages (not `javax.*`)
- [ ] DTOs have Request/Response suffix
- [ ] @Valid on controller parameters
- [ ] JPQL uses parameterized queries
- [ ] No System.out.println or e.printStackTrace()
- [ ] @Transactional for multi-step operations

### Frontend (Angular/TypeScript)
- [ ] Using Angular 19 control flow (`@if`, `@for`, not `*ngIf`/`*ngFor`/`*ngSwitch`)
- [ ] Signals for state management
- [ ] OnPush change detection
- [ ] Standalone components (no NgModules)
- [ ] Component prefix: spa-
- [ ] Signal variables end with Sig suffix
- [ ] Private fields use # prefix
- [ ] Subscriptions cleaned up with takeUntil or take(1)
- [ ] No console.log statements
- [ ] trackBy in @for loops

### Database (Flyway)
- [ ] Sequential version number
- [ ] utf8mb4 charset with utf8mb4_unicode_ci collation
- [ ] No idempotent DDL logic
- [ ] Seeds updated if schema changed

## Security Checklist

- [ ] Input validation with Bean Validation (@NotNull, @Size, @Pattern)
- [ ] No SQL injection vulnerabilities (parameterized queries)
- [ ] No sensitive data logged (passwords, tokens, PII)
- [ ] API errors truncated (500 chars max)
- [ ] Authorization checks added where needed (@PreAuthorize)

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests pass
- [ ] Manual testing completed
- [ ] Edge cases considered

### Test Coverage
<!-- Describe what was tested -->

- 
- 

## Screenshots (if applicable)

<!-- Add screenshots for UI changes -->

## Performance Impact

<!-- Does this PR affect performance? -->

- [ ] No performance impact
- [ ] Performance improved
- [ ] Performance impact acceptable (explain below)

## Migration Required

- [ ] Database migration included
- [ ] Data migration required
- [ ] Configuration changes needed
- [ ] No migration needed

## Reviewer Notes

<!-- Any specific areas you want reviewers to focus on? -->

---

## Pre-Merge Checklist (Reviewer)

- [ ] Code follows all architecture rules
- [ ] No security vulnerabilities introduced
- [ ] Tests pass and coverage is adequate
- [ ] Documentation updated if needed
- [ ] Breaking changes documented
- [ ] Ready to merge

---

**cc: @copilot please review this PR according to `.github/copilot-instructions.md`**
