### PR TITLE
fix(traefik): fix storefront routing for fork-per-tenant model

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -115,8 +115,7 @@ services:
       # Demo/reference storefront shipped from this repo.
       # Tenant-specific storefronts are deployed separately via deploy-tenant-storefront.sh.
       # Matches tenant subdomains; excludes prod API and admin panel hosts.
-      - "traefik.http.routers.storefront.rule=HostRegexp(`{subdomain:[a-z0-9-]+}.${DOMAIN}`) && !Host(`api.${DOMAIN}`) && !Host(`app.${DOMAIN}`)"
-      - "traefik.http.routers.storefront.ruleSyntax=v2"
+      - "traefik.http.routers.storefront.rule=HostRegexp(`[a-z0-9-]+\\.${DOMAIN}`) && !Host(`api.${DOMAIN}`) && !Host(`app.${DOMAIN}`)"
       - "traefik.http.routers.storefront.priority=1"
       - "traefik.http.routers.storefront.entrypoints=websecure"
       - "traefik.http.routers.storefront.tls.certresolver=letsencrypt"

--- a/docker-compose.stage.yml
+++ b/docker-compose.stage.yml
@@ -39,9 +39,7 @@ services:
       - craftive-network
     labels:
       - "traefik.enable=true"
-      # Matches stage tenant domains in s1-<tenant>.domain format; excludes stage API and admin panel hosts.
-      - "traefik.http.routers.storefront.rule=HostRegexp(`s1-[a-z0-9-]+\\.${DOMAIN}`) && !Host(`s1-api.${DOMAIN}`) && !Host(`s1-app.${DOMAIN}`)"
-      - "traefik.http.routers.storefront.priority=1"
+      - "traefik.http.routers.storefront.rule=Host(`s1-${STOREFRONT_TENANT_SUBDOMAIN:-demo}.${DOMAIN}`)"
       - "traefik.http.routers.storefront.entrypoints=websecure"
       - "traefik.http.routers.storefront.tls.certresolver=letsencrypt"
       - "traefik.http.services.storefront.loadbalancer.server.port=3000"

--- a/scripts/server/deploy-tenant-storefront.sh
+++ b/scripts/server/deploy-tenant-storefront.sh
@@ -124,6 +124,8 @@ services:
     restart: unless-stopped
     environment:
       NODE_ENV: production
+      TENANT_SUBDOMAIN: ${TENANT_SLUG}
+      TENANT_HOSTNAME: ${PRIMARY_DOMAIN}
     networks:
       - craftive-network
     labels:


### PR DESCRIPTION
## Summary

- **Root cause**: `docker-compose.prod.yml` had `ruleSyntax=v2` label which leaked into stage deploys via compose file merging — Traefik v3 couldn't parse the route → 404
- **Fallback removed**: Replaced broad `HostRegexp` (catches all `s1-*.craftive.io`) with specific `Host(s1-demo.craftive.io)` — fork-per-tenant has no need for a fallback container
- **Deploy script fixed**: `deploy-tenant-storefront.sh` now passes `TENANT_SUBDOMAIN` and `TENANT_HOSTNAME` env vars so the same storefront image works for any tenant via runtime config

## Changes

| File | Change |
|------|--------|
| `docker-compose.prod.yml` | Remove `ruleSyntax=v2`, update to Traefik v3 `HostRegexp` syntax |
| `docker-compose.stage.yml` | Replace `HostRegexp` fallback with specific `Host()` rule, remove `priority=1` |
| `scripts/server/deploy-tenant-storefront.sh` | Pass `TENANT_SUBDOMAIN` + `TENANT_HOSTNAME` to tenant containers |

## Test plan

- [x] `s1-demo.craftive.io` → demo site loads ✓
- [x] `s1-unknown.craftive.io` → Traefik 404 (no matching container) ✓
- [ ] New tenant deploy: `bash scripts/server/deploy-tenant-storefront.sh stage acme <image>` → `s1-acme.craftive.io` loads acme content

🤖 Generated with [Claude Code](https://claude.com/claude-code)