### PR TITLE
Migrate production storage to R2 and optimize  Droplet

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,18 +56,21 @@ EMAIL_FROM_ADDRESS=noreply@craftive.io
 EMAIL_FROM_NAME=Craftive
 
 # ===========================================
-# OBJECT STORAGE (DigitalOcean Spaces / S3-compatible)
+# OBJECT STORAGE (S3-compatible: Cloudflare R2, MinIO, etc.)
 # ===========================================
 # Dev only: override storage provider for local S3/MinIO testing.
 # DO NOT set this in .env.stage or .env.prod — application-stage/prod.yml already hardcodes provider=s3.
 # Setting STORAGE_PROVIDER=local in stage/prod would break uploads.
 STORAGE_PROVIDER=local
 
-# Stage: craftive-media-stage  |  Prod: craftive-media-prod
-# Use separate key pairs per environment (stage key cannot touch prod bucket).
-# Required when STORAGE_PROVIDER=s3 (i.e. all stage/prod deploys).
-SPACES_ACCESS_KEY=
-SPACES_SECRET_KEY=
+# Use separate key pairs per environment. Cloudflare R2 uses region "auto".
+# Required when STORAGE_PROVIDER=s3 (all stage/prod deploys).
+STORAGE_S3_ENDPOINT=
+STORAGE_S3_BUCKET=
+STORAGE_S3_REGION=auto
+STORAGE_S3_ACCESS_KEY=
+STORAGE_S3_SECRET_KEY=
+STORAGE_S3_CDN_BASE_URL=
 
 # ===========================================
 # TIMEZONE

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           cache: 'maven'
 
       - name: Compile
-        run: ./mvnw -q -pl backend -DskipTests compile
+        run: ./mvnw -q -f backend/pom.xml -DskipTests compile
 
       - name: Migration immutability check
         run: bash scripts/migrations/check-versioned-immutability.sh
@@ -46,7 +46,7 @@ jobs:
           cache: 'maven'
 
       - name: Run tests
-        run: ./mvnw -pl backend test
+        run: ./mvnw -f backend/pom.xml test
 
   frontend-ci:
     name: Frontend — Build Check (Angular)

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -99,7 +99,7 @@ jobs:
           host: ${{ secrets.PROD_DROPLET_IP }}
           username: deploy
           key: ${{ secrets.DROPLET_SSH_PRIVATE_KEY }}
-          source: "docker-compose.yml,docker-compose.prod.yml"
+          source: "docker-compose.yml,docker-compose.prod.yml,docker-compose.prod-small.yml"
           target: /opt/craftive/prod
 
       - name: Save current version
@@ -154,11 +154,12 @@ jobs:
             export CMS_PREVIEW_SECRET="${{ secrets.CMS_PREVIEW_SECRET_PROD }}"
             export APP_ANALYTICS_GA4_SERVICE_ACCOUNT_JSON_BASE64="${{ secrets.APP_ANALYTICS_GA4_JSON_BASE64_PROD }}"
 
-            docker compose -f docker-compose.yml -f docker-compose.prod.yml \
-              --env-file .env.prod pull
+            docker compose -f docker-compose.yml -f docker-compose.prod.yml -f docker-compose.prod-small.yml \
+              --env-file .env.prod pull mysql-db backend frontend traefik
 
-            docker compose -f docker-compose.yml -f docker-compose.prod.yml \
-              --env-file .env.prod up -d --remove-orphans --force-recreate
+            docker compose -f docker-compose.yml -f docker-compose.prod.yml -f docker-compose.prod-small.yml \
+              --env-file .env.prod up -d --remove-orphans --force-recreate \
+              mysql-db backend frontend traefik
 
             echo "${APP_VERSION}" > .last-deployed-tag
 
@@ -223,8 +224,9 @@ jobs:
             export GHCR_ORG=${{ github.repository_owner }}
             export CMS_PREVIEW_SECRET="${{ secrets.CMS_PREVIEW_SECRET_PROD }}"
             export APP_ANALYTICS_GA4_SERVICE_ACCOUNT_JSON_BASE64="${{ secrets.APP_ANALYTICS_GA4_JSON_BASE64_PROD }}"
-            docker compose -f docker-compose.yml -f docker-compose.prod.yml \
-              --env-file .env.prod up -d --remove-orphans
+            docker compose -f docker-compose.yml -f docker-compose.prod.yml -f docker-compose.prod-small.yml \
+              --env-file .env.prod up -d --remove-orphans \
+              mysql-db backend frontend traefik
             echo "Rollback complete: $PREV_TAG"
 
       - name: Smoke test — Admin panel

--- a/.github/workflows/migration-guardrails.yml
+++ b/.github/workflows/migration-guardrails.yml
@@ -36,4 +36,4 @@ jobs:
         run: bash scripts/migrations/lint-migrations.sh
 
       - name: Backend compile sanity
-        run: ./mvnw -q -pl backend -DskipTests compile
+        run: ./mvnw -q -f backend/pom.xml -DskipTests compile

--- a/backend/src/main/java/com/backend/infrastructure/config/S3Config.java
+++ b/backend/src/main/java/com/backend/infrastructure/config/S3Config.java
@@ -26,16 +26,16 @@ public class S3Config {
     public S3Client s3Client() {
         StorageConfigProperties.S3 s3 = properties.getS3();
         if (s3.getAccessKey() == null || s3.getAccessKey().isBlank()) {
-            throw new IllegalStateException("SPACES_ACCESS_KEY must be set when storage provider is s3");
+            throw new IllegalStateException("STORAGE_S3_ACCESS_KEY must be set when storage provider is s3");
         }
         if (s3.getSecretKey() == null || s3.getSecretKey().isBlank()) {
-            throw new IllegalStateException("SPACES_SECRET_KEY must be set when storage provider is s3");
+            throw new IllegalStateException("STORAGE_S3_SECRET_KEY must be set when storage provider is s3");
         }
         if (s3.getEndpoint() == null || s3.getEndpoint().isBlank()) {
-            throw new IllegalStateException("SPACES_ENDPOINT must be set when storage provider is s3");
+            throw new IllegalStateException("STORAGE_S3_ENDPOINT must be set when storage provider is s3");
         }
         if (s3.getBucket() == null || s3.getBucket().isBlank()) {
-            throw new IllegalStateException("SPACES_BUCKET must be set when storage provider is s3");
+            throw new IllegalStateException("STORAGE_S3_BUCKET must be set when storage provider is s3");
         }
         return S3Client.builder()
                 .endpointOverride(URI.create(s3.getEndpoint()))

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -38,12 +38,12 @@ craftive:
   storage:
     provider: s3
     s3:
-      endpoint: https://fra1.digitaloceanspaces.com
-      bucket: craftive-media-prod
-      region: fra1
-      cdn-base-url: https://media.craftive.io
-      access-key: ${SPACES_ACCESS_KEY}
-      secret-key: ${SPACES_SECRET_KEY}
+      endpoint: ${STORAGE_S3_ENDPOINT}
+      bucket: ${STORAGE_S3_BUCKET}
+      region: ${STORAGE_S3_REGION:auto}
+      cdn-base-url: ${STORAGE_S3_CDN_BASE_URL}
+      access-key: ${STORAGE_S3_ACCESS_KEY}
+      secret-key: ${STORAGE_S3_SECRET_KEY}
 
 app:
   jwt:

--- a/backend/src/main/resources/application-stage.yml
+++ b/backend/src/main/resources/application-stage.yml
@@ -37,12 +37,12 @@ craftive:
   storage:
     provider: s3
     s3:
-      endpoint: https://fra1.digitaloceanspaces.com
-      bucket: craftive-media-stage
-      region: fra1
-      cdn-base-url: https://s1-cdn.craftive.io
-      access-key: ${SPACES_ACCESS_KEY}
-      secret-key: ${SPACES_SECRET_KEY}
+      endpoint: ${STORAGE_S3_ENDPOINT}
+      bucket: ${STORAGE_S3_BUCKET}
+      region: ${STORAGE_S3_REGION:auto}
+      cdn-base-url: ${STORAGE_S3_CDN_BASE_URL}
+      access-key: ${STORAGE_S3_ACCESS_KEY}
+      secret-key: ${STORAGE_S3_SECRET_KEY}
 
 app:
   jwt:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -168,12 +168,12 @@ craftive:
       auto-generate-formats: THUMBNAIL,SMALL,MEDIUM
       supported-image-types: image/jpeg,image/png,image/gif,image/webp
     s3:
-      endpoint: ${SPACES_ENDPOINT:}
-      bucket: ${SPACES_BUCKET:}
-      region: ${SPACES_REGION:fra1}
-      access-key: ${SPACES_ACCESS_KEY:}
-      secret-key: ${SPACES_SECRET_KEY:}
-      cdn-base-url: ${SPACES_CDN_URL:}
+      endpoint: ${STORAGE_S3_ENDPOINT:}
+      bucket: ${STORAGE_S3_BUCKET:}
+      region: ${STORAGE_S3_REGION:auto}
+      access-key: ${STORAGE_S3_ACCESS_KEY:}
+      secret-key: ${STORAGE_S3_SECRET_KEY:}
+      cdn-base-url: ${STORAGE_S3_CDN_BASE_URL:}
       delete-local-after-migration: false
 
 resilience4j:

--- a/backend/src/main/resources/templates/email/demo-request-confirmation-en.html
+++ b/backend/src/main/resources/templates/email/demo-request-confirmation-en.html
@@ -278,7 +278,7 @@
                     <td class="header-top" style="width: 50%">
                       <!--[if !mso]><!-->
                       <img
-                        src="https://craftive-media-prod.fra1.cdn.digitaloceanspaces.com/craftive-light.png"
+                        src="https://media.craftive.io/craftive-light.png"
                         alt="Craftive"
                         width="116"
                         height="22"

--- a/backend/src/main/resources/templates/email/demo-request-confirmation-tr.html
+++ b/backend/src/main/resources/templates/email/demo-request-confirmation-tr.html
@@ -278,7 +278,7 @@
                     <td class="header-top" style="width: 50%">
                       <!--[if !mso]><!-->
                       <img
-                        src="https://craftive-media-prod.fra1.cdn.digitaloceanspaces.com/craftive-light.png"
+                        src="https://media.craftive.io/craftive-light.png"
                         alt="Craftive"
                         width="116"
                         height="22"

--- a/backend/src/main/resources/templates/email/email-verify-en.html
+++ b/backend/src/main/resources/templates/email/email-verify-en.html
@@ -278,7 +278,7 @@
                     <td class="header-top" style="width: 50%">
                       <!--[if !mso]><!-->
                       <img
-                        src="https://craftive-media-prod.fra1.cdn.digitaloceanspaces.com/craftive-light.png"
+                        src="https://media.craftive.io/craftive-light.png"
                         alt="Craftive"
                         width="116"
                         height="22"

--- a/backend/src/main/resources/templates/email/email-verify-tr.html
+++ b/backend/src/main/resources/templates/email/email-verify-tr.html
@@ -278,7 +278,7 @@
                     <td class="header-top" style="width: 50%">
                       <!--[if !mso]><!-->
                       <img
-                        src="https://craftive-media-prod.fra1.cdn.digitaloceanspaces.com/craftive-light.png"
+                        src="https://media.craftive.io/craftive-light.png"
                         alt="Craftive"
                         width="116"
                         height="22"

--- a/backend/src/main/resources/templates/email/login-otp-en.html
+++ b/backend/src/main/resources/templates/email/login-otp-en.html
@@ -278,7 +278,7 @@
                     <td class="header-top" style="width: 50%">
                       <!--[if !mso]><!-->
                       <img
-                        src="https://craftive-media-prod.fra1.cdn.digitaloceanspaces.com/craftive-light.png"
+                        src="https://media.craftive.io/craftive-light.png"
                         alt="Craftive"
                         width="116"
                         height="22"

--- a/backend/src/main/resources/templates/email/login-otp-tr.html
+++ b/backend/src/main/resources/templates/email/login-otp-tr.html
@@ -278,7 +278,7 @@
                     <td class="header-top" style="width: 50%">
                       <!--[if !mso]><!-->
                       <img
-                        src="https://craftive-media-prod.fra1.cdn.digitaloceanspaces.com/craftive-light.png"
+                        src="https://media.craftive.io/craftive-light.png"
                         alt="Craftive"
                         width="116"
                         height="22"

--- a/backend/src/main/resources/templates/email/newsletter-confirm-en.html
+++ b/backend/src/main/resources/templates/email/newsletter-confirm-en.html
@@ -278,7 +278,7 @@
                     <td class="header-top" style="width: 50%">
                       <!--[if !mso]><!-->
                       <img
-                        src="https://craftive-media-prod.fra1.cdn.digitaloceanspaces.com/craftive-light.png"
+                        src="https://media.craftive.io/craftive-light.png"
                         alt="Craftive"
                         width="116"
                         height="22"

--- a/backend/src/main/resources/templates/email/newsletter-confirm-tr.html
+++ b/backend/src/main/resources/templates/email/newsletter-confirm-tr.html
@@ -278,7 +278,7 @@
                     <td class="header-top" style="width: 50%">
                       <!--[if !mso]><!-->
                       <img
-                        src="https://craftive-media-prod.fra1.cdn.digitaloceanspaces.com/craftive-light.png"
+                        src="https://media.craftive.io/craftive-light.png"
                         alt="Craftive"
                         width="116"
                         height="22"

--- a/backend/src/main/resources/templates/email/operation-otp-en.html
+++ b/backend/src/main/resources/templates/email/operation-otp-en.html
@@ -278,7 +278,7 @@
                     <td class="header-top" style="width: 50%">
                       <!--[if !mso]><!-->
                       <img
-                        src="https://craftive-media-prod.fra1.cdn.digitaloceanspaces.com/craftive-light.png"
+                        src="https://media.craftive.io/craftive-light.png"
                         alt="Craftive"
                         width="116"
                         height="22"

--- a/backend/src/main/resources/templates/email/operation-otp-tr.html
+++ b/backend/src/main/resources/templates/email/operation-otp-tr.html
@@ -278,7 +278,7 @@
                     <td class="header-top" style="width: 50%">
                       <!--[if !mso]><!-->
                       <img
-                        src="https://craftive-media-prod.fra1.cdn.digitaloceanspaces.com/craftive-light.png"
+                        src="https://media.craftive.io/craftive-light.png"
                         alt="Craftive"
                         width="116"
                         height="22"

--- a/backend/src/main/resources/templates/email/outreach-education-center-tr.html
+++ b/backend/src/main/resources/templates/email/outreach-education-center-tr.html
@@ -272,7 +272,7 @@
                     <td class="header-top" style="width: 50%">
                       <!--[if !mso]><!-->
                       <img
-                        src="https://craftive-media-prod.fra1.cdn.digitaloceanspaces.com/craftive-light.png"
+                        src="https://media.craftive.io/craftive-light.png"
                         alt="Craftive"
                         width="116"
                         height="22"

--- a/backend/src/main/resources/templates/email/password-reset-en.html
+++ b/backend/src/main/resources/templates/email/password-reset-en.html
@@ -278,7 +278,7 @@
                     <td class="header-top" style="width: 50%">
                       <!--[if !mso]><!-->
                       <img
-                        src="https://craftive-media-prod.fra1.cdn.digitaloceanspaces.com/craftive-light.png"
+                        src="https://media.craftive.io/craftive-light.png"
                         alt="Craftive"
                         width="116"
                         height="22"

--- a/backend/src/main/resources/templates/email/password-reset-tr.html
+++ b/backend/src/main/resources/templates/email/password-reset-tr.html
@@ -278,7 +278,7 @@
                     <td class="header-top" style="width: 50%">
                       <!--[if !mso]><!-->
                       <img
-                        src="https://craftive-media-prod.fra1.cdn.digitaloceanspaces.com/craftive-light.png"
+                        src="https://media.craftive.io/craftive-light.png"
                         alt="Craftive"
                         width="116"
                         height="22"

--- a/backend/src/test/java/com/backend/application/service/impl/ProductTypeServiceImplTest.java
+++ b/backend/src/test/java/com/backend/application/service/impl/ProductTypeServiceImplTest.java
@@ -356,16 +356,21 @@ class ProductTypeServiceImplTest extends BaseServiceTest {
         }
 
         @Test
-        @DisplayName("Should throw exception when generated code is duplicate")
-        void addAttribute_ThrowsException_WhenCodeDuplicate() {
+        @DisplayName("Should append a suffix when generated code is duplicate")
+        void addAttribute_GeneratesUniqueCode_WhenCodeDuplicate() {
             // Given
             when(productTypeRepository.findById(1L)).thenReturn(Optional.of(testProductType));
-            when(attributeDefinitionRepository.existsByProductTypeIdAndCode(eq(1L), anyString())).thenReturn(true);
+            when(attributeDefinitionRepository.existsByProductTypeIdAndCode(1L, "name")).thenReturn(true);
+            when(attributeDefinitionRepository.existsByProductTypeIdAndCode(1L, "name_1")).thenReturn(false);
+            when(attributeDefinitionRepository.save(any(ProductAttributeDefinition.class)))
+                    .thenAnswer(inv -> inv.getArgument(0));
 
-            // When & Then
-            assertThatThrownBy(() -> productTypeService.addAttribute(
-                    1L, "Name", ProductFieldType.TEXT))
-                    .isInstanceOf(IllegalArgumentException.class);
+            // When
+            ProductAttributeDefinition result = productTypeService.addAttribute(
+                    1L, "Name", ProductFieldType.TEXT);
+
+            // Then
+            assertThat(result.getCode()).isEqualTo("name_1");
         }
 
         @Test

--- a/backend/src/test/java/com/backend/application/service/impl/config/ConfigPropertiesAdminServiceImplTest.java
+++ b/backend/src/test/java/com/backend/application/service/impl/config/ConfigPropertiesAdminServiceImplTest.java
@@ -53,7 +53,7 @@ class ConfigPropertiesAdminServiceImplTest extends BaseServiceTest {
 
         List<ConfigPropertyResult> result = service.listProperties(tenantPrincipal());
 
-        assertThat(result).hasSize(7);
+        assertThat(result).hasSize(8);
         assertThat(result).extracting(ConfigPropertyResult::key).containsExactly(
                 "security.recaptcha.enabled",
                 "security.recaptcha.site_key",
@@ -61,7 +61,8 @@ class ConfigPropertiesAdminServiceImplTest extends BaseServiceTest {
                 "analytics.ga4.enabled",
                 "analytics.ga4.property_id",
                 "seo.insights.enabled",
-                "seo.search_console.property_url");
+                "seo.search_console.property_url",
+                "security.otp.resend_cooldown_seconds");
         assertThat(result.get(0).value()).isEqualTo("false");
         assertThat(result.get(1).value()).isNull();
         assertThat(result.get(2).value()).isNull();
@@ -74,6 +75,8 @@ class ConfigPropertiesAdminServiceImplTest extends BaseServiceTest {
         assertThat(result.get(5).secret()).isFalse();
         assertThat(result.get(6).value()).isNull();
         assertThat(result.get(6).secret()).isFalse();
+        assertThat(result.get(7).value()).isEqualTo("180");
+        assertThat(result.get(7).secret()).isFalse();
     }
 
     @Test

--- a/backend/src/test/java/com/backend/infrastructure/config/SecurityHeadersTest.java
+++ b/backend/src/test/java/com/backend/infrastructure/config/SecurityHeadersTest.java
@@ -19,6 +19,9 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.backend.infrastructure.security.JwtAuthenticationFilter;
 import com.backend.infrastructure.tenant.TenantFilter;
+import com.backend.application.cms.preview.CmsPreviewTicketService;
+import com.backend.application.cms.preview.CmsRequestContext;
+import com.backend.domain.port.TenantContextPort;
 
 @WebMvcTest(controllers = SecurityHeadersTest.PingController.class)
 @Import({ SecurityConfig.class, SecurityHeadersTest.TestCorsConfig.class })
@@ -33,6 +36,15 @@ class SecurityHeadersTest {
 
     @MockBean
     private TenantFilter tenantFilter;
+
+    @MockBean
+    private CmsPreviewTicketService cmsPreviewTicketService;
+
+    @MockBean
+    private CmsRequestContext cmsRequestContext;
+
+    @MockBean
+    private TenantContextPort tenantContextPort;
 
     @Test
     @DisplayName("X-Frame-Options: DENY present on all responses")

--- a/docker-compose.prod-small.yml
+++ b/docker-compose.prod-small.yml
@@ -1,0 +1,27 @@
+# Craftive production overlay for the $6 / 1 GB DigitalOcean Droplet.
+#
+# Keep the platform stack intentionally small. The production workflow starts
+# only mysql-db, backend, frontend and traefik; the active tenant storefront is
+# deployed separately with scripts/server/deploy-tenant-storefront.sh.
+services:
+  mysql-db:
+    deploy:
+      resources:
+        limits:
+          memory: 384M
+        reservations:
+          memory: 192M
+
+  backend:
+    environment:
+      JAVA_TOOL_OPTIONS: >-
+        -Xms128m -Xmx256m -XX:+UseSerialGC
+        -XX:+ExitOnOutOfMemoryError
+    deploy:
+      resources:
+        limits:
+          cpus: "0.75"
+          memory: 512M
+        reservations:
+          cpus: "0.25"
+          memory: 256M

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -42,8 +42,12 @@ services:
       PLATFORM_DOMAIN: ${PLATFORM_DOMAIN}
       EMAIL_FROM_ADDRESS: ${EMAIL_FROM_ADDRESS}
       EMAIL_FROM_NAME: ${EMAIL_FROM_NAME}
-      SPACES_ACCESS_KEY: ${SPACES_ACCESS_KEY}
-      SPACES_SECRET_KEY: ${SPACES_SECRET_KEY}
+      STORAGE_S3_ACCESS_KEY: ${STORAGE_S3_ACCESS_KEY}
+      STORAGE_S3_SECRET_KEY: ${STORAGE_S3_SECRET_KEY}
+      STORAGE_S3_ENDPOINT: ${STORAGE_S3_ENDPOINT}
+      STORAGE_S3_BUCKET: ${STORAGE_S3_BUCKET}
+      STORAGE_S3_REGION: ${STORAGE_S3_REGION:-auto}
+      STORAGE_S3_CDN_BASE_URL: ${STORAGE_S3_CDN_BASE_URL}
       APP_SEO_CRUX_API_KEY: ${APP_SEO_CRUX_API_KEY}
       CMS_PREVIEW_SECRET: ${CMS_PREVIEW_SECRET}
       APP_ANALYTICS_GA4_SERVICE_ACCOUNT_JSON_BASE64: ${APP_ANALYTICS_GA4_SERVICE_ACCOUNT_JSON_BASE64}
@@ -177,6 +181,12 @@ services:
       - "--certificatesresolvers.letsencrypt.acme.dnschallenge.resolvers=1.1.1.1:53,8.8.8.8:53"
       - "--certificatesresolvers.letsencrypt.acme.email=${ACME_EMAIL}"
       - "--certificatesresolvers.letsencrypt.acme.storage=/letsencrypt/acme.json"
+      # Custom tenant domains use HTTP-01 so their certificate lifecycle does
+      # not require the platform Cloudflare token to cover every customer zone.
+      - "--certificatesresolvers.letsencrypt-http.acme.httpchallenge=true"
+      - "--certificatesresolvers.letsencrypt-http.acme.httpchallenge.entrypoint=web"
+      - "--certificatesresolvers.letsencrypt-http.acme.email=${ACME_EMAIL}"
+      - "--certificatesresolvers.letsencrypt-http.acme.storage=/letsencrypt/acme-http.json"
     environment:
       CF_API_TOKEN: ${CF_API_TOKEN}
       CLOUDFLARE_DNS_API_TOKEN: ${CF_API_TOKEN}

--- a/docker-compose.stage.yml
+++ b/docker-compose.stage.yml
@@ -14,8 +14,12 @@ services:
           cpus: '0.25'
           memory: 256M
     environment:
-      SPACES_ACCESS_KEY: ${SPACES_ACCESS_KEY}
-      SPACES_SECRET_KEY: ${SPACES_SECRET_KEY}
+      STORAGE_S3_ACCESS_KEY: ${STORAGE_S3_ACCESS_KEY}
+      STORAGE_S3_SECRET_KEY: ${STORAGE_S3_SECRET_KEY}
+      STORAGE_S3_ENDPOINT: ${STORAGE_S3_ENDPOINT}
+      STORAGE_S3_BUCKET: ${STORAGE_S3_BUCKET}
+      STORAGE_S3_REGION: ${STORAGE_S3_REGION:-auto}
+      STORAGE_S3_CDN_BASE_URL: ${STORAGE_S3_CDN_BASE_URL}
       APP_SEO_CRUX_API_KEY: ${APP_SEO_CRUX_API_KEY}
     labels:
       traefik.http.routers.backend.rule: "Host(`s1-api.${DOMAIN}`)"

--- a/docs/global/devops.md
+++ b/docs/global/devops.md
@@ -19,6 +19,7 @@ Prelaunch secret/config readiness checklist: [`../prelaunch.md`](../prelaunch.md
 | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Base services                | [`../../docker-compose.yml`](../../docker-compose.yml)                                                                                                                   |
 | Production overrides         | [`../../docker-compose.prod.yml`](../../docker-compose.prod.yml)                                                                                                         |
+| 1 GB production limits       | [`../../docker-compose.prod-small.yml`](../../docker-compose.prod-small.yml)                                                                                             |
 | Stage overrides              | [`../../docker-compose.stage.yml`](../../docker-compose.stage.yml)                                                                                                       |
 | Dev overrides                | [`../../docker-compose.dev.yml`](../../docker-compose.dev.yml)                                                                                                           |
 | Next.js SSR image            | [`../../docker/storefront/Dockerfile`](../../docker/storefront/Dockerfile)                                                                                               |
@@ -50,6 +51,7 @@ Prelaunch secret/config readiness checklist: [`../prelaunch.md`](../prelaunch.md
 - **Production requires reviewer approval.** The `production` GitHub Environment gate must not be bypassed.
 - **Ports 3306, 8080, 3000 are never externally reachable.** UFW allows only 22, 80, 443.
 - **Wildcard SSL (`*.craftive.io`) requires DNS-01.** HTTP-01 cannot issue wildcard certs; Cloudflare is the DNS provider.
+- **Custom tenant domains use HTTP-01.** This keeps certificate issuance and renewal independent from customer DNS-zone permissions in the platform Cloudflare token.
 - **Cloudflare SSL mode must be Full (strict) for prod.** Flexible mode breaks backend TLS validation. Stage DNS records use DNS-only (grey cloud) — Traefik serves Let's Encrypt certs directly.
 - **Stage subdomains use single-level `s1-*` convention.** Cloudflare Universal SSL covers `*.craftive.io` (single level only). Stage services use `s1-api`, `s1-app`, `s1-cdn` (hyphen, single-level) so Cloudflare proxy (orange cloud) works. Old two-level patterns (`s1.api`, `s1.app`) caused `ERR_SSL_VERSION_OR_CIPHER_MISMATCH` and required DNS-only mode.
 - **Backend requires `spring-boot-starter-actuator`.** Health checks depend on `/api/actuator/health`. Without this dependency, all health checks fail and Traefik marks the backend as unhealthy.
@@ -57,6 +59,7 @@ Prelaunch secret/config readiness checklist: [`../prelaunch.md`](../prelaunch.md
 - **CORS is profile-driven, not hardcoded.** `allowedOrigins` and `allowedOriginPatterns` come from `CorsProperties` bound to `application-{env}.yml`; `SecurityConfig` must not contain hardcoded origin strings.
 - **`deploy` user has docker group only — no sudo.** Workflows SSH as `deploy`, never root.
 - **Prod images are tagged with release date** (`release-DD.MM.YYYY` + `latest`). Stage images use `stage-{sha}`.
+- **The $6 / 1 GB production Droplet uses `docker-compose.prod-small.yml`.** The platform deploy starts only MySQL, backend, frontend, and Traefik. The shared demo storefront and Alloy are omitted; tenant storefronts remain separate and default to a 256 MB limit.
 - **Tenant storefront deploy is isolated per tenant.** Every tenant storefront runs as a separate compose project (`tenant-{env}-{slug}`), with its own router labels and domains.
 - **Centralized logs flow to Grafana Cloud Loki via Alloy.** Stage and prod hosts run Alloy as part of compose; Grafana users are account seats (not tenant count).
 - **Alloy mounts Docker socket (read-only flag; accepted risk).** Required for container log discovery. The `:ro` flag does not restrict Unix socket API access. Mitigation: Alloy container is isolated to `craftive-network` with no published ports. Future option: use a socket proxy allowlist.
@@ -375,14 +378,14 @@ Stage inherits the same middleware values from `docker-compose.prod.yml` and onl
 | `PROD_DROPLET_IP`                         | `deploy-prod.yml`                                                                                              |
 | `STAGE_DROPLET_IP`                        | `deploy-stage.yml`                                                                                             |
 | `CF_API_TOKEN`                            | Traefik DNS-01 (injected via `.env.*`)                                                                         |
-| `ENV_PROD`                                | `.env.prod` content, base64-encoded — must include `SPACES_ACCESS_KEY` / `SPACES_SECRET_KEY` for prod bucket   |
-| `ENV_STAGE`                               | `.env.stage` content, base64-encoded — must include `SPACES_ACCESS_KEY` / `SPACES_SECRET_KEY` for stage bucket |
+| `ENV_PROD`                                | `.env.prod` content, base64-encoded — includes the `STORAGE_S3_*` variables for Cloudflare R2                 |
+| `ENV_STAGE`                               | `.env.stage` content, base64-encoded — includes provider-specific `STORAGE_S3_*` variables                    |
 | `CMS_PREVIEW_SECRET_PROD`                 | `deploy-prod.yml` — exported as shell env var, NOT in `ENV_PROD`                                               |
 | `CMS_PREVIEW_SECRET_STAGE`                | `deploy-stage.yml` — exported as shell env var, NOT in `ENV_STAGE`                                             |
 | `APP_ANALYTICS_GA4_JSON_BASE64_PROD`      | `deploy-prod.yml` — exported as shell env var, NOT in `ENV_PROD`                                               |
 | `APP_ANALYTICS_GA4_JSON_BASE64_STAGE`     | `deploy-stage.yml` — exported as shell env var, NOT in `ENV_STAGE`                                             |
 
-Use separate DO Spaces key pairs for stage and prod (stage key compromise cannot affect prod bucket).
+Use separate object-storage key pairs for stage and prod (a stage key must never access the prod bucket).
 
 `GITHUB_TOKEN` is auto-injected by GitHub Actions (no explicit secret needed for GHCR push).
 
@@ -528,11 +531,10 @@ bash scripts/server/deploy-files.sh prod <PROD_IP>
 Daily cron (03:00 UTC+3) on each Droplet, run by `deploy` user:
 
 ```
-mysqldump --all-databases | gzip → DO Spaces: craftive-backups/{env}/YYYY-MM-DD.sql.gz
+mysqldump --all-databases | gzip → Cloudflare R2: craftive-backups-prod/database/YYYY-MM-DD/
 ```
 
-`rclone` credentials are stored in `/home/deploy/.config/rclone/rclone.conf` so cron and manual backup runs use the same user context.
-30-day retention enforced via Spaces lifecycle policy.
+R2 credentials are stored in `/home/deploy/.config/rclone/rclone.conf`; the backup job runs the official rclone container with that config mounted read-only. Local dumps are retained for 7 days. Configure an R2 lifecycle rule separately when remote retention is required.
 
 ### Rollback pattern (platform)
 
@@ -548,11 +550,10 @@ Manual rollback (if needed):
 Daily cron (03:00 UTC+3) on each Droplet, run by `deploy` user:
 
 ```
-mysqldump --all-databases | gzip → DO Spaces: craftive-backups/{env}/YYYY-MM-DD.sql.gz
+mysqldump --all-databases | gzip → Cloudflare R2: craftive-backups-prod/database/YYYY-MM-DD/
 ```
 
-`rclone` credentials are stored in `/home/deploy/.config/rclone/rclone.conf` so cron and manual backup runs use the same user context.
-30-day retention enforced via Spaces lifecycle policy.
+R2 credentials are stored in `/home/deploy/.config/rclone/rclone.conf`; the backup job runs the official rclone container with that config mounted read-only. Local dumps are retained for 7 days. Configure an R2 lifecycle rule separately when remote retention is required.
 
 ### Rollback pattern (platform)
 
@@ -595,8 +596,8 @@ docker compose -f docker-compose.yml -f docker-compose.prod.yml --env-file .env.
 - **DigitalOcean blocks outbound SMTP port 587 by default.** Request unblock via DO support ticket for email functionality. Until then, `management.health.mail.enabled` must be `false` to prevent health check timeouts.
 - **`docker-compose.stage.yml` is an overlay only.** It adds stage-specific routing (`s1-api.*`, `s1-app.*`, `s1-<tenant>.*`) and the storefront service; always layer it on top of `docker-compose.yml` and `docker-compose.prod.yml`.
 - **Traefik v3 dropped `{name:regexp}` HostRegexp syntax.** The stage storefront router uses `ruleSyntax=v2` label to keep the existing `s1-{subdomain:[a-z0-9-]+}` pattern working. Remove this label only after migrating to v3 syntax.
-- **Cloudflare Origin Rule (Host Header Override) is Enterprise-only.** Cloudflare proxy sends `Host: s1-cdn.craftive.io` to DO Spaces, which cannot resolve the bucket and returns `AccessDenied`. Origin Rules that override the Host header require Enterprise plan. Solution: use a **Cloudflare Worker** as reverse proxy — it rewrites the hostname to the DO Spaces CDN endpoint before forwarding (`craftive-media-stage.fra1.cdn.digitaloceanspaces.com`). CDN DNS records use `AAAA 100::` (dummy IPv6, Proxied) so the Worker intercepts all requests.
-- **DO Spaces CDN must be enabled (without custom domain).** Worker proxies to the DO CDN endpoint (`fra1.cdn.digitaloceanspaces.com`), so origin-level caching is active. Do not add a custom subdomain in DO Spaces CDN settings — custom subdomain requires the domain to be managed on DigitalOcean DNS.
-- **S3 objects must be uploaded with `public-read` ACL.** DO Spaces objects are private by default. Without `ObjectCannedACL.PUBLIC_READ` on `PutObjectRequest`, CDN delivery always returns `AccessDenied` regardless of DNS or proxy configuration.
+- **Prod media is served directly from Cloudflare R2.** `media.craftive.io` is the R2 custom domain for `craftive-media-prod`; no Worker route may overlap `media.craftive.io/*`. An old Spaces proxy Worker route takes precedence over R2 and makes newly uploaded R2-only objects return 403.
+- **Stage storage is provider-configured.** If a future stage environment uses a different S3-compatible provider, set all `STORAGE_S3_*` values explicitly and keep its credentials isolated from prod.
+- **Public access is provider-specific.** The S3 adapter sends the broadly compatible `public-read` canned ACL, while R2 public delivery is controlled at bucket custom-domain level. Keep `media.craftive.io` enabled on the R2 bucket.
 - **Cloudflare Cache Rule hostname must match the actual CDN subdomain exactly.** A rule matching `s1.media.craftive.io` does not apply to `s1-cdn.craftive.io`. Verify the Cache Rule expression after any CDN domain rename. When using Workers, the Worker route (`s1-cdn.craftive.io/*`) takes precedence — Cache Rules apply to Worker responses as normal.
 - **Alloy `stage.replace` replaces the capture group, not the full match.** When a regex has a capture group `(...)`, only the captured portion is substituted. Use `(?:...)` for non-capturing groups and place `(...)` only around the value to redact. Example: `"(?:password|secret)\\s*[:=]\\s*(\\S+)"` replaces only the credential value, keeping the keyword intact.

--- a/docs/global/environment-configuration.md
+++ b/docs/global/environment-configuration.md
@@ -298,8 +298,12 @@ npm run build:static
 | `PLATFORM_DOMAIN`       | Platform domain                | Yes                |
 | `EMAIL_FROM_ADDRESS`    | Default sender email           | Yes                |
 | `EMAIL_FROM_NAME`       | Default sender name            | Yes                |
-| `SPACES_ACCESS_KEY`     | DO Spaces access key (S3)      | Yes (stage/prod)   |
-| `SPACES_SECRET_KEY`     | DO Spaces secret key (S3)      | Yes (stage/prod)   |
+| `STORAGE_S3_ENDPOINT`   | S3-compatible API endpoint     | Yes (stage/prod)   |
+| `STORAGE_S3_BUCKET`     | Media object bucket            | Yes (stage/prod)   |
+| `STORAGE_S3_REGION`     | S3 region (`auto` for R2)      | Yes (stage/prod)   |
+| `STORAGE_S3_ACCESS_KEY` | S3-compatible access key       | Yes (stage/prod)   |
+| `STORAGE_S3_SECRET_KEY` | S3-compatible secret key       | Yes (stage/prod)   |
+| `STORAGE_S3_CDN_BASE_URL` | Public media custom domain   | Yes (stage/prod)   |
 | `APP_ANALYTICS_GA4_SERVICE_ACCOUNT_JSON` | GA4 service account JSON content | Yes, if GA4 dashboard reporting is enabled |
 | `APP_ANALYTICS_GA4_SERVICE_ACCOUNT_JSON_BASE64` | Base64 alternative for GA4 service account JSON | Optional alternative |
 | `APP_SEO_CRUX_API_KEY` | CrUX History API key | Yes, if SEO insights performance snapshot is enabled |

--- a/docs/modules/platform-provisioning.md
+++ b/docs/modules/platform-provisioning.md
@@ -40,6 +40,14 @@ Base path: `/api/tenants`
 - `GET /api/tenants/{tenantId}/provisioning-jobs` (provisioning job history)
 - `POST /api/tenants/{id}/generate-admin` (generate tenant admin credentials)
 
+> **TODO — Safe tenant decommissioning:** The current `DELETE /api/tenants/{id}`
+> implementation removes only the platform tenant record. Before exposing a delete
+> action in the admin UI, implement an Application-layer decommission workflow that
+> validates and drops the physical tenant database, evicts its datasource pool,
+> preserves failure recovery, and documents cleanup of independently deployed tenant
+> storefronts. Add a destructive confirmation action to the tenant list only after
+> the backend lifecycle is covered by tests.
+
 `GET /api/tenants` supports list pagination/sort/search:
 
 - Query params: `page`, `size`, `sort`, `search`, `status`

--- a/scripts/server/configure-rclone.sh
+++ b/scripts/server/configure-rclone.sh
@@ -1,13 +1,12 @@
 #!/usr/bin/env bash
 # =============================================================================
-# configure-rclone.sh — Configure DO Spaces backup
+# configure-rclone.sh — Configure Cloudflare R2 backup
 # =============================================================================
 # Usage: bash scripts/server/configure-rclone.sh
 #
 # Requirements:
-#   - DO Spaces bucket: craftive-backups (Frankfurt / FRA1)
-#   - DO Spaces Access Key + Secret Key
-#     (DigitalOcean → API → Spaces Keys → Generate New Key)
+#   - R2 bucket: craftive-backups-prod
+#   - R2 account endpoint, Access Key ID, and Secret Access Key
 # =============================================================================
 
 set -euo pipefail
@@ -20,7 +19,7 @@ NC='\033[0m'
 log()  { echo -e "${GREEN}[✓]${NC} $1"; }
 warn() { echo -e "${YELLOW}[!]${NC} $1"; }
 
-echo -e "\n${BOLD}rclone — DO Spaces Configuration${NC}\n"
+echo -e "\n${BOLD}rclone — Cloudflare R2 Configuration${NC}\n"
 
 command -v rclone &>/dev/null || { echo "rclone is not installed. Run provision-droplet.sh first."; exit 1; }
 
@@ -41,8 +40,9 @@ DEPLOY_HOME="$(getent passwd "${DEPLOY_USER}" | cut -d: -f6)"
 RCLONE_CONFIG_DIR="${DEPLOY_HOME}/.config/rclone"
 
 # Interactive input
-read -rp "DO Spaces Access Key: " SPACES_ACCESS_KEY
-read -rsp "DO Spaces Secret Key: " SPACES_SECRET_KEY
+read -rp "Cloudflare account ID: " R2_ACCOUNT_ID
+read -rp "R2 Access Key ID: " R2_ACCESS_KEY
+read -rsp "R2 Secret Access Key: " R2_SECRET_KEY
 echo
 
 mkdir -p "${RCLONE_CONFIG_DIR}"
@@ -52,14 +52,15 @@ mkdir -p "${RCLONE_CONFIG_DIR}"
      "${RCLONE_CONFIG_DIR}/rclone.conf.bak.$(date +%Y%m%d_%H%M%S)"
 
 cat > "${RCLONE_CONFIG_DIR}/rclone.conf" <<EOF
-[spaces]
+[r2]
 type = s3
-provider = DigitalOcean
-access_key_id = ${SPACES_ACCESS_KEY}
-secret_access_key = ${SPACES_SECRET_KEY}
-endpoint = fra1.digitaloceanspaces.com
-region = fra1
+provider = Cloudflare
+access_key_id = ${R2_ACCESS_KEY}
+secret_access_key = ${R2_SECRET_KEY}
+endpoint = https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com
+region = auto
 acl = private
+no_check_bucket = true
 EOF
 
 chmod 600 "${RCLONE_CONFIG_DIR}/rclone.conf"
@@ -72,25 +73,25 @@ log "rclone configuration saved"
 echo -e "\n${BOLD}Testing connection...${NC}"
 if [[ "${CURRENT_USER}" == "root" ]]; then
   if command -v runuser &>/dev/null; then
-    if runuser -u "${DEPLOY_USER}" -- rclone ls spaces:craftive-backups --max-depth 1 &>/dev/null; then
-      log "DO Spaces connection successful: craftive-backups bucket is reachable"
+    if runuser -u "${DEPLOY_USER}" -- rclone ls r2:craftive-backups-prod --max-depth 1 &>/dev/null; then
+      log "Cloudflare R2 connection successful: craftive-backups-prod is reachable"
     else
       warn "Connection failed — check Access Key, Secret Key, and bucket name"
-      warn "Bucket: DigitalOcean -> Spaces -> craftive-backups (Frankfurt/FRA1)"
+      warn "Bucket: Cloudflare R2 -> craftive-backups-prod"
     fi
   else
-    if su -s /bin/bash -c "rclone ls spaces:craftive-backups --max-depth 1" "${DEPLOY_USER}" &>/dev/null; then
-      log "DO Spaces connection successful: craftive-backups bucket is reachable"
+    if su -s /bin/bash -c "rclone ls r2:craftive-backups-prod --max-depth 1" "${DEPLOY_USER}" &>/dev/null; then
+      log "Cloudflare R2 connection successful: craftive-backups-prod is reachable"
     else
       warn "Connection failed — check Access Key, Secret Key, and bucket name"
-      warn "Bucket: DigitalOcean -> Spaces -> craftive-backups (Frankfurt/FRA1)"
+      warn "Bucket: Cloudflare R2 -> craftive-backups-prod"
     fi
   fi
-elif rclone ls spaces:craftive-backups --max-depth 1 &>/dev/null; then
-  log "DO Spaces connection successful: craftive-backups bucket is reachable"
+elif rclone ls r2:craftive-backups-prod --max-depth 1 &>/dev/null; then
+  log "Cloudflare R2 connection successful: craftive-backups-prod is reachable"
 else
   warn "Connection failed — check Access Key, Secret Key, and bucket name"
-  warn "Bucket: DigitalOcean -> Spaces -> craftive-backups (Frankfurt/FRA1)"
+  warn "Bucket: Cloudflare R2 -> craftive-backups-prod"
 fi
 
 echo -e "\n${BOLD}Backup test reminder...${NC}"

--- a/scripts/server/deploy-tenant-storefront.sh
+++ b/scripts/server/deploy-tenant-storefront.sh
@@ -56,10 +56,14 @@ PRIMARY_DOMAIN="${4:-}"
 EXTRA_DOMAINS_CSV="${5:-}"
 CANONICAL_HOST="${6:-}"
 BASE_DOMAIN="${BASE_DOMAIN:-craftive.io}"
+TENANT_MEMORY_LIMIT="${TENANT_MEMORY_LIMIT:-256M}"
+TENANT_CPU_LIMIT="${TENANT_CPU_LIMIT:-0.50}"
 
 [[ "${ENV}" != "stage" && "${ENV}" != "prod" ]] && error "Environment must be 'stage' or 'prod'."
 [[ "${TENANT_SLUG}" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]] || error "Invalid tenant slug: ${TENANT_SLUG}"
 [[ "${IMAGE_REF}" =~ ^[^[:space:]]+$ ]] || error "Image reference must not contain spaces."
+[[ "${TENANT_MEMORY_LIMIT}" =~ ^[1-9][0-9]*(M|G)$ ]] || error "Invalid TENANT_MEMORY_LIMIT: ${TENANT_MEMORY_LIMIT}"
+[[ "${TENANT_CPU_LIMIT}" =~ ^[0-9]+([.][0-9]+)?$ ]] || error "Invalid TENANT_CPU_LIMIT: ${TENANT_CPU_LIMIT}"
 
 if [[ "${IMAGE_REF}" != *:* && "${IMAGE_REF}" != *@* ]]; then
   warn "Image reference has no explicit tag/digest: ${IMAGE_REF}"
@@ -73,6 +77,25 @@ if [[ -z "${PRIMARY_DOMAIN}" ]]; then
     PRIMARY_DOMAIN="s1-${TENANT_SLUG}.${BASE_DOMAIN}"
   else
     PRIMARY_DOMAIN="${TENANT_SLUG}.${BASE_DOMAIN}"
+  fi
+fi
+
+if [[ -z "${CMS_API_URL:-}" ]]; then
+  if [[ "${ENV}" == "stage" ]]; then
+    CMS_API_URL="https://s1-api.${BASE_DOMAIN}/api"
+  else
+    CMS_API_URL="https://api.${BASE_DOMAIN}/api"
+  fi
+fi
+
+# Platform-owned craftive.io hosts use the DNS-01 resolver (required for the
+# wildcard certificate). Customer-owned custom domains use HTTP-01 so Traefik
+# can issue and renew certificates without access to each customer's DNS zone.
+if [[ -z "${CERT_RESOLVER:-}" ]]; then
+  if [[ "${PRIMARY_DOMAIN}" == "${BASE_DOMAIN}" || "${PRIMARY_DOMAIN}" == *."${BASE_DOMAIN}" ]]; then
+    CERT_RESOLVER="letsencrypt"
+  else
+    CERT_RESOLVER="letsencrypt-http"
   fi
 fi
 
@@ -151,7 +174,7 @@ if [[ "${#REDIRECT_DOMAINS[@]}" -gt 0 ]]; then
   REDIRECT_LABELS+="      traefik.http.middlewares.${ROUTER_NAME}-canonical.redirectregex.permanent: \"true\"\n"
   REDIRECT_LABELS+="      traefik.http.routers.${ROUTER_NAME}-redirect.rule: \"${REDIRECT_HOST_RULE}\"\n"
   REDIRECT_LABELS+="      traefik.http.routers.${ROUTER_NAME}-redirect.entrypoints: \"websecure\"\n"
-  REDIRECT_LABELS+="      traefik.http.routers.${ROUTER_NAME}-redirect.tls.certresolver: \"letsencrypt\"\n"
+  REDIRECT_LABELS+="      traefik.http.routers.${ROUTER_NAME}-redirect.tls.certresolver: \"${CERT_RESOLVER}\"\n"
   REDIRECT_LABELS+="      traefik.http.routers.${ROUTER_NAME}-redirect.middlewares: \"${ROUTER_NAME}-canonical@docker\"\n"
   REDIRECT_LABELS+="      traefik.http.routers.${ROUTER_NAME}-redirect.priority: \"20\"\n"
   REDIRECT_LABELS+="      traefik.http.routers.${ROUTER_NAME}-redirect.service: \"${ROUTER_NAME}@docker\"\n"
@@ -164,15 +187,22 @@ services:
     restart: unless-stopped
     environment:
       NODE_ENV: production
+      HOSTNAME: "0.0.0.0"
       TENANT_SUBDOMAIN: ${TENANT_SLUG}
       TENANT_HOSTNAME: ${PRIMARY_DOMAIN}
+      NEXT_PUBLIC_CMS_API_URL: ${CMS_API_URL}
+    deploy:
+      resources:
+        limits:
+          memory: ${TENANT_MEMORY_LIMIT}
+          cpus: "${TENANT_CPU_LIMIT}"
     networks:
       - craftive-network
     labels:
       traefik.enable: "true"
       traefik.http.routers.${ROUTER_NAME}.rule: "${MAIN_HOST_RULE}"
       traefik.http.routers.${ROUTER_NAME}.entrypoints: "websecure"
-      traefik.http.routers.${ROUTER_NAME}.tls.certresolver: "letsencrypt"
+      traefik.http.routers.${ROUTER_NAME}.tls.certresolver: "${CERT_RESOLVER}"
       traefik.http.routers.${ROUTER_NAME}.priority: "20"
       traefik.http.services.${ROUTER_NAME}.loadbalancer.server.port: "3000"
 $(printf '%b' "${REDIRECT_LABELS}")
@@ -184,9 +214,13 @@ EOF
 log "Rendered compose: ${COMPOSE_FILE}"
 log "Deploying tenant storefront (${TENANT_SLUG}) to ${ENV}..."
 
-log "Pulling image ${IMAGE_REF}..."
-if ! docker compose -p "${PROJECT_NAME}" -f "${COMPOSE_FILE}" pull; then
-  error "docker compose pull failed — leaving existing stack running."
+if [[ "${TENANT_SKIP_PULL:-false}" == "true" ]]; then
+  warn "TENANT_SKIP_PULL=true — using the image already present on the host"
+else
+  log "Pulling image ${IMAGE_REF}..."
+  if ! docker compose -p "${PROJECT_NAME}" -f "${COMPOSE_FILE}" pull; then
+    error "docker compose pull failed — leaving existing stack running."
+  fi
 fi
 
 # Tear down previous stack so recreate/up does not hit Docker container name conflicts.
@@ -212,4 +246,3 @@ echo "  Image       : ${IMAGE_REF}"
 echo "  Project     : ${PROJECT_NAME}"
 echo "  Domains     : ${DOMAINS[*]}"
 [[ -n "${CANONICAL_HOST}" ]] && echo "  Canonical   : ${CANONICAL_HOST} (301 from: ${REDIRECT_DOMAINS[*]:-none})"
-

--- a/scripts/server/provision-droplet.sh
+++ b/scripts/server/provision-droplet.sh
@@ -12,6 +12,11 @@
 
 set -euo pipefail
 
+# Package operations run over non-interactive SSH during provisioning. Keep the
+# image's existing config files so upgrades cannot block waiting for input.
+export DEBIAN_FRONTEND=noninteractive
+APT_GET=(apt-get -o Dpkg::Options::=--force-confold)
+
 # -----------------------------------------------------------------------------
 # Colors & helpers
 # -----------------------------------------------------------------------------
@@ -52,9 +57,9 @@ echo -e "${BOLD}═════════════════════�
 # 1. System update
 # -----------------------------------------------------------------------------
 section "Updating system packages"
-apt-get update -qq
-apt-get upgrade -y -qq
-apt-get install -y -qq \
+"${APT_GET[@]}" update -qq
+"${APT_GET[@]}" upgrade -y -qq
+"${APT_GET[@]}" install -y -qq \
   curl wget git unzip \
   ca-certificates gnupg \
   ufw fail2ban \
@@ -97,8 +102,8 @@ else
     https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
     | tee /etc/apt/sources.list.d/docker.list > /dev/null
 
-  apt-get update -qq
-  apt-get install -y -qq docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+  "${APT_GET[@]}" update -qq
+  "${APT_GET[@]}" install -y -qq docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
   systemctl enable --now docker
   log "Docker CE installed: $(docker --version)"
 fi
@@ -263,7 +268,7 @@ section "Setting up backup system"
 
 cat > /opt/craftive/backup.sh <<BACKUP_EOF
 #!/usr/bin/env bash
-# Craftive — MySQL Backup to DO Spaces
+# Craftive — MySQL Backup to Cloudflare R2
 # Cron: runs daily at 03:00
 
 set -euo pipefail
@@ -291,16 +296,17 @@ docker exec "\${CONTAINER}" mysqldump \\
 
 echo "\$(date): Backup created: \${DUMP_FILE} (\$(du -sh \${DUMP_FILE} | cut -f1))"
 
-# Upload to DO Spaces (rclone must be installed/configured)
-if command -v rclone &>/dev/null; then
-  rclone copy "\${DUMP_FILE}" "spaces:craftive-backups/\${ENV}/\${DATE}/" --quiet
-  echo "\$(date): Uploaded to DO Spaces"
-  rm -f "\${DUMP_FILE}"
-else
-  echo "\$(date): WARNING: rclone is not installed, backup kept locally"
-fi
+# Upload through the rclone container. The host config is owned by deploy and
+# mounted read-only so cron does not need a native rclone installation.
+RCLONE_CONFIG_DIR="/home/${DEPLOY_USER}/.config/rclone"
+docker run --rm --memory=128m \
+  -v "\${RCLONE_CONFIG_DIR}:/config/rclone:ro" \
+  -v "\${BACKUP_DIR}:\${BACKUP_DIR}:ro" \
+  rclone/rclone:latest copy "\${DUMP_FILE}" \
+  "r2:craftive-backups-prod/database/\${DATE}/" --s3-no-check-bucket --quiet
+echo "\$(date): Uploaded to Cloudflare R2"
 
-# Delete local backups older than 7 days (Spaces handles 30-day retention)
+# Keep a seven-day local recovery window.
 find "\${BACKUP_DIR}" -name "*.sql.gz" -mtime +7 -delete
 BACKUP_EOF
 
@@ -310,7 +316,9 @@ chown "${DEPLOY_USER}:${DEPLOY_USER}" /opt/craftive/backup.sh
 # Cron job — daily at 03:00 (UTC+3 = 00:00 UTC)
 CRON_JOB="0 0 * * * /opt/craftive/backup.sh >> /opt/craftive/logs/backup.log 2>&1"
 if ! crontab -l -u "${DEPLOY_USER}" 2>/dev/null | grep -qF "backup.sh"; then
-  (crontab -l -u "${DEPLOY_USER}" 2>/dev/null; echo "${CRON_JOB}") | crontab -u "${DEPLOY_USER}" -
+  # `crontab -l` exits with 1 when the user has no crontab yet. That is an
+  # expected first-run state and must not abort provisioning under pipefail.
+  (crontab -l -u "${DEPLOY_USER}" 2>/dev/null || true; echo "${CRON_JOB}") | crontab -u "${DEPLOY_USER}" -
   log "Backup cron job added: daily at 03:00 (Istanbul)"
 else
   warn "Backup cron job already exists"
@@ -337,12 +345,12 @@ log "Log rotation: 14 days, daily compression"
 # -----------------------------------------------------------------------------
 # 12. rclone install (for DO Spaces)
 # -----------------------------------------------------------------------------
-section "Installing rclone (DO Spaces backup)"
+section "Installing rclone (Cloudflare R2 backup)"
 
 if command -v rclone &>/dev/null; then
   warn "rclone is already installed: $(rclone --version | head -1)"
 else
-  apt-get install -y -qq rclone
+  "${APT_GET[@]}" install -y -qq rclone
   log "rclone installed: $(rclone --version | head -1)"
 fi
 


### PR DESCRIPTION
## Summary
- migrate production media and database backups from DigitalOcean Spaces to Cloudflare R2
- make S3 configuration provider-neutral with STORAGE_S3_* variables
- add the 1 GB production Compose overlay and deploy only the minimal platform services
- update tenant storefront limits, certificate resolver selection, email media URLs, runbooks, and tenant deletion TODO

## Production infrastructure already verified
- api.craftive.io health: 200
- ahmetmulayim.com: 200
- media.craftive.io existing and newly uploaded R2 objects: 200
- R2 backup upload: successful
- obsolete media.craftive.io/* DigitalOcean proxy Worker route removed

## Verification
- Maven compile: passed
- Maven test-compile: passed
- Docker Compose config render: passed
- Linux shell syntax checks: passed